### PR TITLE
add tag {{term-slug}} to be used in templates

### DIFF
--- a/templates/checkbox-item.html
+++ b/templates/checkbox-item.html
@@ -1,6 +1,6 @@
 <li class="term-item {{#is-selected}}current-term{{/is-selected}}">
-	<label>
-		<input type="checkbox" name="{{name}}" value="{{value}}" {{#is-selected}}checked="checked"{{/is-selected}} />
+	<label for="{{term-slug}}>
+		<input type="checkbox" id="{{term-slug}}" name="{{name}}" value="{{value}}" {{#is-selected}}checked="checked"{{/is-selected}} />
 		{{{term-name}}}
 	</label>
 	{{#children}}

--- a/walkers.php
+++ b/walkers.php
@@ -114,6 +114,7 @@ abstract class QMT_Walker extends Walker {
 		$data = $this->specific_data( $term, $depth );
 
 		$data = array_merge( $data, array(
+			'term-slug' => $term->slug,
 			'term-name' => $term->name,
 			'is-selected' => in_array( $term->slug, $this->selected_terms ) ? array(true) : false,
 			'depth' => $depth,


### PR DESCRIPTION
I had to move the input out of the label, so I needed an ID to reference the label to. Therefore I added a new tag that uses the slug of the category as identifier.
