### PR TITLE
Declare static methods explicitly

### DIFF
--- a/core.php
+++ b/core.php
@@ -63,7 +63,7 @@ class QMT_Terms {
 	private static $filtered_ids;
 
 	// Get a list of all the terms attached to all the posts in the current query
-	public function get( $tax ) {
+	public static function get( $tax ) {
 		self::set_filtered_ids();
 
 		if ( empty( self::$filtered_ids ) )
@@ -79,7 +79,7 @@ class QMT_Terms {
 		return $terms;
 	}
 
-	private function set_filtered_ids() {
+	private static function set_filtered_ids() {
 		global $wp_query;
 
 		if ( isset( self::$filtered_ids ) )
@@ -284,4 +284,3 @@ function qmt_get_terms( $tax ) {
 	else
 		return get_terms( $tax );
 }
-


### PR DESCRIPTION
If E_STRICT is enabled PHP complains that a couple of static methods are called non-statically.

Feel free to ignore this if you don't care - it probably won't affect anything in a context where error reporting is disabled. OTOH, since neither method makes reference to $this, there's really no reason not to make this change.